### PR TITLE
update docs to use layouts directory instead of files

### DIFF
--- a/docs/api-documentation/layouts/diagrams.md
+++ b/docs/api-documentation/layouts/diagrams.md
@@ -6,13 +6,13 @@ sidebar_position: 4
 
 Diagrams are created using [React Flow](https://reactflow.dev/).
 
-:::info diagrams.json
+:::info diagrams directory
 
-Create a `src/vision/layouts/diagrams.json` file (case-sensitive)
+Create a `src/vision/layouts/diagrams` directory (case-sensitive)
 
 :::
 
-The `src/vision/layouts/diagrams.json` file is responsible for: 
+The `src/vision/layouts/diagrams` directory is responsible for: 
 
 - Defining what OML Vision Diagrams can render
   - Name of the Diagrams
@@ -22,12 +22,12 @@ The `src/vision/layouts/diagrams.json` file is responsible for:
   - Queries for the Diagram edge content
   - How to map Diagrams node queries to edge queries
 
-It is formatted as a JSON data structure.
+Each file in the directory is formatted as a JSON data structure.
 
 <!-- TODO: Change to opencaesar repo -->
-An example of what this looks like is seen below with the source code found [here](https://github.com/UTNAK/open-source-rover/blob/main/src/vision/layouts/diagramLayouts.json)
+An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/diagrams)
 
-## Defining Diagram
+## Defining A Diagram
 
 A Diagram must be properly defined in order to be rendered by OML Vision
 
@@ -68,7 +68,7 @@ name: string
 :::
 
 
-This string gives a name to the Diagram in the `diagramLayouts.json` file.  
+This string gives a name to the Diagram.  
 
 ### queries
 :::danger REQUIRED
@@ -159,7 +159,7 @@ The `labelFormat` is rendered in the rows of the Diagram shown in the red boxes.
 
 OML Vision supports string interpolation with the queries that were formatted.  The format is `"{string}"`.  Please visit the sparql section of the documentation for more info located [here](/docs/api-documentation/sparql)  
 
-An example is found [here](https://github.com/UTNAK/open-source-rover/blob/main/src/vision/layouts/diagramLayouts.json#L11)
+An example is found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/diagrams/components.json#L11)
 
 ![Diagram Column Names](./img/diagramRowMappingLabelFormat.png)
 

--- a/docs/api-documentation/layouts/pages.md
+++ b/docs/api-documentation/layouts/pages.md
@@ -30,47 +30,6 @@ It is formatted as a JSON data structure.
 <!-- TODO: Change to opencaesar repo -->
 An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/pages.json)
 
-```json
-[
-  { "title": "Home", "path": "/", "treeIcon": "home" },
-  {
-    "title": "Kepler16b",
-    "treeIcon": "server",
-    "iconUrl": "https://nasa-jpl.github.io/stellar/icons/satellite.svg",
-    "children": [
-      { 
-        "title": "Objectives",
-        "treeIcon": "window",
-        "path": "objectives" 
-      },
-      {
-        "title": "Missions",
-        "treeIcon": "graph-scatter",
-        "path": "missions",
-        "isDiagram": true
-      },
-      {
-        "title": "Components",
-        "treeIcon": "list-tree",
-        "path": "components",
-        "isTree": true
-      },
-      {
-        "title": "Connections",
-        "treeIcon": "window",
-        "path": "connections"
-      },
-      {
-        "title": "Requirements",
-        "treeIcon": "list-tree",
-        "path": "requirements",
-        "isTree": true
-      }
-    ]
-  }
-]
-```
-
 ## Home Page
 
 The home page acts as an entry point for users to navigate through the pages that OML Vision renders.
@@ -119,7 +78,34 @@ The name of the `path` is rendered in the sidebar when you hover and hold for 2 
 
 :::
 
-### treeIcon
+### type
+:::danger REQUIRED
+
+```typescript
+type: string
+```
+
+:::
+
+
+This string defines the type of the webview to be rendered. 
+
+The type of webview determines the icon that is rendered in the sidebar.
+
+**The icons that are rendered come from [here](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing).**
+
+:::tip TYPES
+
+These are the current types
+1. `home` -  This type renders the Home Page.
+2. `group` - This type groups webviews together in the Home Page and sidebar. Grouping is only done in the UI.
+3. `table` - This type specifies the webview to render a table.  For more info, look [here](/docs/api-documentation/layouts/tables.md)
+4. `tree` - This type specifies the webview to render a tree.  For more info, look [here](/docs/api-documentation/layouts/trees.md)
+5. `diagram` - This type specifies the webview to render a diagram.  For more info, look [here](/docs/api-documentation/layouts/diagrams.md)
+
+:::
+
+### treeIcon (DEPRECATED)
 :::note OPTIONAL
 
 ```typescript
@@ -167,7 +153,34 @@ The name of the `title` is rendered in the sidebar and in the `Home Page`.
 
 :::
 
-### treeIcon
+### type
+:::danger REQUIRED
+
+```typescript
+type: string
+```
+
+:::
+
+
+This string defines the type of the webview to be rendered. 
+
+The type of webview determines the icon that is rendered in the sidebar.
+
+**The icons that are rendered come from [here](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing).**
+
+:::tip TYPES
+
+These are the current types
+1. `home` -  This type renders the Home Page.
+2. `group` - This type groups webviews together in the Home Page and sidebar. Grouping is only done in the UI.
+3. `table` - This type specifies the webview to render a table.  For more info, look [here](/docs/api-documentation/layouts/tables.md)
+4. `tree` - This type specifies the webview to render a tree.  For more info, look [here](/docs/api-documentation/layouts/trees.md)
+5. `diagram` - This type specifies the webview to render a diagram.  For more info, look [here](/docs/api-documentation/layouts/diagrams.md)
+
+:::
+
+### treeIcon (DEPRECATED)
 :::note OPTIONAL
 
 ```typescript
@@ -216,16 +229,14 @@ The `Child Page` icon of the `iconUrl` is rendered in the `Home Page` in the OML
 children: {
     title: string;
     path: string;
-    treeIcon: string;
-    isTree: boolean;
-    isDiagram: boolean;
+    type: string;
   }[];
 ```
 
 :::
 
 
-This `children` array of objects defines the `title`, `path`, and `treeIcon` of the `Child Page`. 
+This `children` array of objects defines the `title`, `path`, and `type` of the `Child Page`. 
 
 **You can more than one `Child Page` in the `children` array.**
 
@@ -277,7 +288,34 @@ The name of the `path` is rendered in the sidebar when you hover and hold for 2 
 
 :::
 
-#### treeIcon
+#### type
+:::danger REQUIRED
+
+```typescript
+type: string
+```
+
+:::
+
+
+This string defines the type of the webview to be rendered. 
+
+The type of webview determines the icon that is rendered in the sidebar.
+
+**The icons that are rendered come from [here](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing).**
+
+:::tip TYPES
+
+These are the current types
+1. `home` -  This type renders the Home Page.
+2. `group` - This type groups webviews together in the Home Page and sidebar. Grouping is only done in the UI.
+3. `table` - This type specifies the webview to render a table.  For more info, look [here](/docs/api-documentation/layouts/tables.md)
+4. `tree` - This type specifies the webview to render a tree.  For more info, look [here](/docs/api-documentation/layouts/trees.md)
+5. `diagram` - This type specifies the webview to render a diagram.  For more info, look [here](/docs/api-documentation/layouts/diagrams.md)
+
+:::
+
+#### treeIcon (DEPRECATED)
 :::note OPTIONAL
 
 ```typescript
@@ -297,7 +335,7 @@ The `Child Page` icon of the `treeIcon` is rendered in the sidebar for the OML V
 
 :::
 
-#### isTree
+#### isTree (DEPRECATED)
 :::note OPTIONAL
 
 ```typescript
@@ -310,7 +348,7 @@ isTree: boolean
 This bool specifies whether or not the `Child Page` will be a tree.  Set `isTree` to `true` to turn the `Child Page` into a tree.
 
 
-#### isDiagram
+#### isDiagram (DEPRECATED)
 :::note OPTIONAL
 
 ```typescript

--- a/docs/api-documentation/layouts/tables.md
+++ b/docs/api-documentation/layouts/tables.md
@@ -6,13 +6,13 @@ sidebar_position: 2
 
 Tables are created using [tanstack table](https://tanstack.com/table/v8).
 
-:::info tables.json
+:::info tables directory
 
-Create a `src/vision/layouts/tables.json` file (case-sensitive)
+Create a `src/vision/layouts/tables` directory (case-sensitive)
 
 :::
 
-The `src/vision/layouts/tables.json` file is responsible for: 
+The `src/vision/layouts/tables` directory is responsible for: 
 
 - Defining what OML Vision Tables can render
   - Name of the Table
@@ -21,59 +21,12 @@ The `src/vision/layouts/tables.json` file is responsible for:
   - Queries that the Table's content needs
   - How to map Table queries to columns
 
-It is formatted as a JSON data structure.
+Each file in the directory is formatted as a JSON data structure.
 
 <!-- TODO: Change to opencaesar repo -->
-An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/tableLayouts.json)
+An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/tables)
 
-```json
-{
-  "objectives": {
-    "name": "Objectives",
-    "diagrams": {
-      "all-rows": "objectives-diagram"
-    },
-    "columnNames": {
-      "o1_id": "Objective 1 ID",
-      "o1_name": "Objective 1 Name",
-      "o2_id": "Objective 2 ID",
-      "o2_name": "Objective 2 Name"
-    },
-    "queries": {
-      "o1_id": "objectives.sparql",
-      "o1_name": "objectives.sparql",
-      "o2_id": "objectives.sparql",
-      "o2_name": "objectives.sparql"
-    },
-    "rowMapping": {
-      "id": "o1_id",
-      "name": "Objectives",
-      "labelFormat": "Objective"
-    }
-  },
-  "connections": {
-    "name": "Connections",
-    "diagrams": {
-      "all-rows": "connections-diagram"
-    },
-    "columnNames": {
-      "c1_name": "Connection 1 Name",
-      "c2_name": "Connection 2 Name"
-    },
-    "queries": {
-      "c1_name": "connections.sparql",
-      "c2_name": "connections.sparql"
-    },
-    "rowMapping": {
-      "id": "c1_name",
-      "name": "Connections",
-      "labelFormat": "Connection"
-    }
-  }
-}
-```
-
-## Defining Table
+## Defining A Table
 
 A table must be properly defined in order to be rendered by OML Vision
 
@@ -107,7 +60,7 @@ name: string
 :::
 
 
-This string gives a name to the table in the `tableLayouts.json` file.  
+This string gives a name to the table.  
 
 <!-- TODO: Change from diagrams to commands -->
 ### diagrams
@@ -249,7 +202,7 @@ The `labelFormat` is rendered in the rows of the Table shown in the red boxes.
 
 OML Vision supports string interpolation with the queries that were formatted.  The format is `"{string}"`  
 
-An example is found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/tableLayouts.json#L25)
+An example is found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/tables/objectives.json#L25)
 
 ![Table String Interpolation](./img/tableStringInterpolation.png)
 

--- a/docs/api-documentation/layouts/trees.md
+++ b/docs/api-documentation/layouts/trees.md
@@ -6,13 +6,13 @@ sidebar_position: 3
 
 Trees are created using [React Arborist](https://github.com/brimdata/react-arborist).
 
-:::info trees.json
+:::info trees directory
 
-Create a `src/vision/layouts/trees.json` file (case-sensitive)
+Create a `src/vision/layouts/trees` directory (case-sensitive)
 
 :::
 
-The `src/vision/layouts/trees.json` file is responsible for: 
+The `src/vision/layouts/trees` directory is responsible for: 
 
 - Defining what OML Vision Trees can render
   - Name of the Trees
@@ -21,59 +21,12 @@ The `src/vision/layouts/trees.json` file is responsible for:
   - Queries that the Trees's content needs
   - How to map Tree queries to columns
 
-It is formatted as a JSON data structure.
+Each file in the directory is formatted as a JSON data structure.
 
 <!-- TODO: Change to opencaesar repo -->
-An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/treeLayouts.json)
+An example of what this looks like is seen below with the source code found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/trees)
 
-```json
-{
-  "requirements": {
-    "name": "Requirements Diagram",
-    "diagrams": {
-      "all-rows": "requirements-diagram"
-    },
-    "queries": {
-      "requirements": "requirements.sparql"
-    },
-    "rowMapping": {
-      "id": "requirements",
-      "name": "Requirements",
-      "labelFormat": "{r_id}",
-      "subRowMappings": [
-        {
-          "id": "requirements",
-          "name": "Components",
-          "labelFormat": "C Name: {c_name}"
-        }
-      ]
-    }
-  },
-  "components": {
-    "name": "Components",
-    "diagrams": {
-      "all-rows": "components-diagram"
-    },
-    "queries": {
-      "components": "components.sparql"
-    },
-    "rowMapping": {
-      "id": "components",
-      "name": "Components",
-      "labelFormat": "{c1_id} {c1_name}",
-      "subRowMappings": [
-        {
-          "id": "components",
-          "name": "Masses",
-          "labelFormat": "{c1_mass}"
-        }
-      ]
-    }
-  }
-}
-```
-
-## Defining Tree
+## Defining A Tree
 
 A tree must be properly defined in order to be rendered by OML Vision
 
@@ -107,7 +60,7 @@ name: string
 :::
 
 
-This string gives a name to the Tree in the `treeLayouts.json` file.  
+This string gives a name to the Tree.  
 
 <!-- TODO: Change from diagrams to commands -->
 ### diagrams
@@ -225,7 +178,7 @@ The `labelFormat` is rendered in the rows of the Tree shown in the red boxes.
 
 OML Vision supports string interpolation with the queries that were formatted.  The format is `"{string}"`  
 
-An example is found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/treeLayouts.json#L18)
+An example is found [here](https://github.com/pogi7/kepler16b-example/blob/main/src/vision/layouts/trees/missions.json#L14)
 
 ![Tree Column Names](./img/treeRowMappingLabelFormat.png)
 


### PR DESCRIPTION
## Checklist before submitting a merge request

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md) document
- [x] All commits have been signed-off for the Developer Certificate of Origin. See [here](https://github.com/opencaesar/oml-vision/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).
- [x] I have added my contribution to [CHANGELOG.md](https://github.com/opencaesar/oml-vision/blob/master/CHANGELOG.md)
- [x] I have documented my code in the [OML Vision Docs](http://www.opencaesar.io/oml-vision-docs/)

## Description of contribution

Look at https://github.com/opencaesar/oml-vision/issues/6 for more details

## Testing performed

Ran `docusaurus start` to test locally.

Ran `docusaurus build` to see how new documentation look like on GitHub Pages.


## Expected functionality changes

New entries in 

- /docs/api-documentation/layouts/pages
- /docs/api-documentation/layouts/tables
- /docs/api-documentation/layouts/trees
- /docs/api-documentation/layouts/diagrams

to replace layouts.json files with layout directories for the possible types of webviews that can be rendered

## Additional context

[If needed, you may add additional context]
